### PR TITLE
Add disconnect reason parameter to BLE

### DIFF
--- a/src/NukiBle.cpp
+++ b/src/NukiBle.cpp
@@ -1195,9 +1195,9 @@ void NukiBle::onConnect(BLEClient*) {
   #endif
 };
 
-void NukiBle::onDisconnect(BLEClient*) {
+void NukiBle::onDisconnect(BLEClient*, int reason) {
   #ifdef DEBUG_NUKI_CONNECT
-  log_d("BLE disconnected");
+  log_d("BLE disconnected, reason: %d", reason);
   #endif
 };
 

--- a/src/NukiBle.h
+++ b/src/NukiBle.h
@@ -329,7 +329,7 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
     unsigned long pairingLastSeen = 0;
 
     void onConnect(BLEClient*) override;
-    void onDisconnect(BLEClient*) override;
+    void onDisconnect(BLEClient*, int) override;
     void onResult(BLEAdvertisedDevice* advertisedDevice) override;
     bool registerOnGdioChar();
     bool registerOnUsdioChar();


### PR DESCRIPTION
Breaking change adding this parameter was introduced in https://github.com/h2zero/NimBLE-Arduino/pull/398.